### PR TITLE
Fix: removed empty chat view definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,28 +161,6 @@
 				"title": "Open File Generator"
 			}
 		],
-		"viewsContainers": {
-			"activitybar": [
-				{
-					"id": "chat",
-					"title": "Chat",
-					"icon": "comments-view-icon"
-				},
-				{
-					"id": "fileGenerator",
-					"title": "File Generator",
-					"icon": "file-generator-view-icon"
-				}
-			]
-		},
-		"views": {
-			"chat": [
-				{
-					"id": "chatPanel",
-					"name": "Accord Assistant"
-				}
-			]
-		},
 		"submenus": [
 			{
 				"id": "accordProjectSubmenu",


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #44 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Removed the unused "chat" view definition from package.json to prevent an empty Accord Assistant chat window from appearing.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Testing should be conducted to confirm that the chat window no longer appears.


### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #44 
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`