### PR TITLE
Refined diagnostics reporting

### DIFF
--- a/server/src/commands/commandHandler.ts
+++ b/server/src/commands/commandHandler.ts
@@ -53,7 +53,7 @@ export async function loadModels() {
 		log(`Document count: ${GLOBAL_STATE.documents.all().length}`);
 		GLOBAL_STATE.documents.all().forEach(async document => {
 			const change: TextDocumentChangeEvent<TextDocument> = { document };
-			handleConcertoDocumentChange(GLOBAL_STATE, change);
+			await handleConcertoDocumentChange(GLOBAL_STATE, change);
 		});
 	} else {
 		log('GLOBAL_STATE.connection is null');

--- a/server/src/documents/concertoHandler.ts
+++ b/server/src/documents/concertoHandler.ts
@@ -89,8 +89,13 @@ export async function handleConcertoDocumentChange(state:LanguageServerState, ch
 			catch (error: any) {
 				if(!state.isLoading) {
 					// we may be offline? Validate without external models
-					state.modelManager.validateModelFiles();
-					state.diagnostics.pushDiagnostic(DiagnosticSeverity.Warning, change.document, error, 'model');
+					if (!navigator.onLine){
+						state.modelManager.validateModelFiles();
+					}
+					// we only report errors for the document that changed, if error has a fileName
+					if(change.document.uri == error.fileName || !error.fileName){
+						state.diagnostics.pushDiagnostic(DiagnosticSeverity.Warning, change.document, error, 'model');
+					}	
 				}
 				else {
 					log(`Ignored model validation error while initializing ${change.document.uri}`);
@@ -99,7 +104,9 @@ export async function handleConcertoDocumentChange(state:LanguageServerState, ch
 		}
 		catch (error: any) {
 			if(!state.isLoading) {
-				state.diagnostics.pushDiagnostic(DiagnosticSeverity.Error, change.document, error, 'model');	
+				if(change.document.uri == error.fileName || !error.fileName){
+					state.diagnostics.pushDiagnostic(DiagnosticSeverity.Error, change.document, error, 'model');
+				}			
 			}
 			else {
 				log(`Ignored model validation error while initializing ${change.document.uri}`);


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #52 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Fixed revalidation logic by explicitly checking online/offline status to avoid incorrect errors during model validation.
- Ensured diagnostic errors are only pushed for the specific document that caused the error by checking the file name.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Earlier, revalidation was automatically triggered even when online, leading to incorrect errors due to missing external imports in offline validations.
- Now, we explicitly check the online status before revalidating, preventing **misleading** error messages.
- For example, if a document contains correct imports along with one incorrect import, the error would incorrectly point to the first external import in the AST, regardless of whether it was actually incorrect. (See Issue #52 for more details)
- Addressed the issue where diagnostics were incorrectly pushed to other files by matching the error's file name with the document URI.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #52
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`