### PR TITLE
enforced deterministic behavior when querying large language models

### DIFF
--- a/server/src/copilot/agent/promptTemplates/concertoInlineTemplate.ts
+++ b/server/src/copilot/agent/promptTemplates/concertoInlineTemplate.ts
@@ -13,7 +13,7 @@ export function getConcertoInlineTemplate(beforeCursor: string, afterCursor: str
             role: "user"
         },
         {
-            content: `${beforeCursor} /* The user's cursor is here. Analyze the following code in concerto language and provide a suggestion to complete it according to this instruction from user: ${instruction}. Only add new code at the cursor position without modifying the existing code. Remove this comment in the final output. */ ${afterCursor}. Start output from here ${beforeCursor}`,
+            content: `Q: ${beforeCursor} /* The user's cursor is here. Analyze the following code in concerto language and provide a suggestion to complete it according to this instruction from user: ${instruction}. Only add new code at the cursor position without modifying the existing code. Remove this comment in the final output. */ ${afterCursor}. Start output from here ${beforeCursor}\nA:`,
             role: "user"
         }
     ];

--- a/server/src/copilot/agent/promptTemplates/concertoModelTemplate.ts
+++ b/server/src/copilot/agent/promptTemplates/concertoModelTemplate.ts
@@ -34,7 +34,7 @@ export function getConcertoModelTemplate(documents: Documents, promptEmbedding: 
     for (const example of relevantTemplates) {
         prompt += `Example:\n\`\`\`\n${example}\n\`\`\`\n\n`;
     }
-    
+
     prompt += DOCUMENTATION.NAMESPACE_INFORMATION;
     prompt += DOCUMENTATION.TRANSACTIONS;
     prompt += DOCUMENTATION.PACKAGE_JSON_INFO;
@@ -56,7 +56,7 @@ export function getConcertoModelTemplate(documents: Documents, promptEmbedding: 
             role: "system"
         },
         {
-            content: prompt,
+            content: `Q: ${prompt}\nA:`,
             role: "user"
         }
     ];

--- a/server/src/copilot/agent/promptTemplates/fixTemplate.ts
+++ b/server/src/copilot/agent/promptTemplates/fixTemplate.ts
@@ -3,7 +3,7 @@ export function getFixTemplate(content: string, promptConfig: any): Array<{ cont
 
     return [
         {
-            content: `${content} // The above code have this error: ${instruction}. Provide the analysis and fixed code. Remove this comment in the fixed code of the analysis.`,
+            content: `Q: ${content} // The above code have this error: ${instruction}. Provide the analysis and fixed code. Remove this comment in the fixed code of the analysis.\nA:`,
             role: "user"
         }
     ];

--- a/server/src/copilot/agent/promptTemplates/generalTemplate.ts
+++ b/server/src/copilot/agent/promptTemplates/generalTemplate.ts
@@ -2,7 +2,7 @@ export function getGeneralTemplate(promptConfig: any): Array<{ content: string, 
     const { instruction } = promptConfig;
     return [
         {
-            content: `${instruction}`,
+            content: `Q: ${instruction}\nA:`,
             role: "user"
         }
     ];

--- a/server/src/copilot/agent/promptTemplates/inlineTemplate.ts
+++ b/server/src/copilot/agent/promptTemplates/inlineTemplate.ts
@@ -9,7 +9,7 @@ export function getInlineTemplate(beforeCursor: string, afterCursor: string, pro
             role: "system"
         },
         {
-            content: `${beforeCursor} /* The user's cursor is here. Analyze the following code in ${language} language and complete it according to this instruction from user: ${instruction}. Only add new code at the cursor position without modifying the existing code. Remove this comment in the final output. */ ${afterCursor}. Start output from here ${beforeCursor}`,
+            content: `Q: ${beforeCursor} /* The user's cursor is here. Analyze the following code in ${language} language and complete it according to this instruction from user: ${instruction}. Only add new code at the cursor position without modifying the existing code. Remove this comment in the final output. */ ${afterCursor}. Start output from here ${beforeCursor}\nA:`,
             role: "user"
         }
     ];

--- a/server/src/copilot/llm/providers/gemini.ts
+++ b/server/src/copilot/llm/providers/gemini.ts
@@ -1,6 +1,6 @@
 import { LargeLanguageModel } from './largeLanguageModel';
 import { Embedding, ModelConfig } from '../../utils/types';
-import  { robustFetch as fetch } from '../../utils/robustFetch';
+import { robustFetch as fetch } from '../../utils/robustFetch';
 import { log } from '../../../state';
 import { DocumentationType } from '../../utils/constants';
 
@@ -99,7 +99,7 @@ class Gemini implements LargeLanguageModel {
         }
 
         return [];
-    } 
+    }
 
     private createGenerateContentRequest(promptArray: { content: string; role: string }[], config: ModelConfig) {
         const { additionalParams } = config;
@@ -111,9 +111,9 @@ class Gemini implements LargeLanguageModel {
             topK?: number;
         } = {};
 
-        if (additionalParams?.temperature !== undefined) generationConfig.temperature = additionalParams.temperature;
+        generationConfig.temperature = additionalParams?.temperature ?? 0;
+        generationConfig.topP = additionalParams?.topP ?? 0.9;
         if (additionalParams?.maxTokens !== undefined) generationConfig.maxOutputTokens = additionalParams.maxTokens;
-        if (additionalParams?.topP !== undefined) generationConfig.topP = additionalParams.topP;
         if (additionalParams?.topK !== undefined) generationConfig.topK = additionalParams.topK;
 
         const contents = promptArray.map(item => ({

--- a/server/src/copilot/llm/providers/mistral.ts
+++ b/server/src/copilot/llm/providers/mistral.ts
@@ -1,5 +1,5 @@
 import { LargeLanguageModel } from './largeLanguageModel';
-import  { robustFetch as fetch } from '../../utils/robustFetch';
+import { robustFetch as fetch } from '../../utils/robustFetch';
 import { log } from '../../../state';
 import { Embedding, ModelConfig } from '../../utils/types';
 import { DocumentationType } from '../../utils/constants';
@@ -99,7 +99,7 @@ class Mistral implements LargeLanguageModel {
         }
 
         return [];
-    } 
+    }
 
     private createGenerateContentRequest(promptArray: { content: string; role: string }[], config: ModelConfig) {
         const { llmModel, additionalParams } = config;
@@ -117,9 +117,9 @@ class Mistral implements LargeLanguageModel {
             messages: promptArray,
         };
 
-        if (additionalParams?.temperature !== undefined) request.temperature = additionalParams.temperature;
+        request.temperature = additionalParams?.temperature ?? 0;
+        request.top_p = additionalParams?.topP ?? 0.9;
         if (additionalParams?.maxTokens !== undefined) request.max_tokens = additionalParams.maxTokens;
-        if (additionalParams?.topP !== undefined) request.top_p = additionalParams.topP;
         if (additionalParams?.frequencyPenalty !== undefined) request.frequency_penalty = additionalParams.frequencyPenalty;
         if (additionalParams?.presencePenalty !== undefined) request.presence_penalty = additionalParams.presencePenalty;
 

--- a/server/src/copilot/llm/providers/ollama.ts
+++ b/server/src/copilot/llm/providers/ollama.ts
@@ -26,7 +26,7 @@ class Ollama implements LargeLanguageModel {
 
         try {
             log(`Sending request to Ollama: ${apiUrl} with model: ${config.llmModel}`);
-            
+
             const response = await fetch(apiUrl, {
                 method: 'POST',
                 headers: {
@@ -59,13 +59,13 @@ class Ollama implements LargeLanguageModel {
     // Embeddings support (Optional, but good to have)
     async generateEmbeddings(config: any, text: string): Promise<Embedding[]> {
         let { apiUrl, embeddingModel } = config;
-        
+
         if (!apiUrl) {
             apiUrl = OLLAMA_ENDPOINTS.EMBEDDINGS;
         }
-        
+
         // Default embedding model for Ollama
-        let model = embeddingModel || 'nomic-embed-text'; 
+        let model = embeddingModel || 'nomic-embed-text';
         const request = this.createGenerateEmbeddingsRequest(text, model);
 
         try {
@@ -102,7 +102,7 @@ class Ollama implements LargeLanguageModel {
                 return data.grammar?.embeddings?.ollama;
         }
         return [];
-    } 
+    }
 
     private createGenerateContentRequest(promptArray: { content: string; role: string }[], config: ModelConfig) {
         const { llmModel, additionalParams } = config;
@@ -114,9 +114,8 @@ class Ollama implements LargeLanguageModel {
             stream: false // Important for Ollama to return JSON at once
         };
 
-        // Add optional params if they exist
-        if (additionalParams?.temperature !== undefined) request.temperature = additionalParams.temperature;
-        
+        request.temperature = additionalParams?.temperature ?? 0;
+        request.top_p = additionalParams?.topP ?? 0.9;
         return request;
     }
 

--- a/server/src/copilot/llm/providers/openai.ts
+++ b/server/src/copilot/llm/providers/openai.ts
@@ -1,6 +1,6 @@
 import { LargeLanguageModel } from './largeLanguageModel';
 import { Embedding, ModelConfig } from '../../utils/types';
-import  { robustFetch as fetch } from '../../utils/robustFetch';
+import { robustFetch as fetch } from '../../utils/robustFetch';
 import { log } from '../../../state';
 import { DocumentationType } from '../../utils/constants';
 
@@ -52,7 +52,7 @@ class OpenAI implements LargeLanguageModel {
     async generateEmbeddings(config: any, text: string): Promise<Embedding[]> {
         const { embeddingModel, accessToken } = config
         let apiUrl = OPENAI_ENDPOINTS.EMBEDDINGS;
-        
+
         let model = embeddingModel || OPENAI_ENDPOINTS.EMBEDDING_MODEL;
         const request = this.createGenerateEmbeddingsRequest(text, model);
 
@@ -98,7 +98,7 @@ class OpenAI implements LargeLanguageModel {
         }
 
         return [];
-    } 
+    }
 
     private createGenerateContentRequest(promptArray: { content: string; role: string }[], config: ModelConfig) {
         const { llmModel, additionalParams } = config;
@@ -116,12 +116,12 @@ class OpenAI implements LargeLanguageModel {
             messages: promptArray,
         };
 
-        if (additionalParams?.temperature !== undefined) request.temperature = additionalParams.temperature;
+        request.temperature = additionalParams?.temperature ?? 0;
+        request.top_p = additionalParams?.topP ?? 0.9;
         if (additionalParams?.maxTokens !== undefined) request.max_tokens = additionalParams.maxTokens;
-        if (additionalParams?.topP !== undefined) request.top_p = additionalParams.topP;
         if (additionalParams?.frequencyPenalty !== undefined) request.frequency_penalty = additionalParams.frequencyPenalty;
         if (additionalParams?.presencePenalty !== undefined) request.presence_penalty = additionalParams.presencePenalty;
-        
+
         return request;
     }
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #50

<!--- Provide an overall summary of the pull request -->
Resolves an issue where the extension's LLM integrations occasionally generated empty or undeterministic conversational responses instead of direct code snippets.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Enforced deterministic LLM configurations (`temperature: 0` and `top_p: 0.9`) across OpenAI, Gemini, Mistral, and Ollama providers to prevent unpredictable token variance when generating code.
- Standardized AI Copilot prompt templates (e.g. `concertoInlineTemplate` and `generalTemplate`) using a rigid `Q: [Prompt]\nA:` format to explicitly steer models into outputting code completions without conversational filler.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Users who intentionally desire more creative outputs from the AI will now need to explicitly override `temperature` in their `additionalParams` settings configuration.
- To successfully run local browser tests, reviewers might need to clear their local `.vscode-test-web` caches.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #50
- Pull Request #

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname` 
