### PR TITLE
fix: update incorrect VS Code documentation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The Accord Project Concerto extension helps developers to create, test and debug [Accord Project](https://accordproject.org) Concerto files.
 
-For a step-by-step guide on getting started with the extension's features, access our [VS Code Extension documentation](https://concerto.accordproject.org/docs/vscode). For more comprehensive Concerto documentation, [follow this link.](https://concerto.accordproject.org)
+For a step-by-step guide on getting started with the extension's features, access our [VS Code Extension documentation](https://concerto.accordproject.org/docs/tools/vscode). For more comprehensive Concerto documentation, [follow this link.](https://concerto.accordproject.org)
 
 ![Accord Project Extension Homepage](assets/VSCodeImage.png)
 


### PR DESCRIPTION
## This change fixes an incorrect path that was pointing to a non-existent page and updates it to the correct location.

### AFTER 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/17c8adc4-00b3-4feb-842e-0f56bc2bc029" />

### BEFORE
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a25d56de-afff-4ab6-966d-94156527da4d" />
