### PR TITLE
fix(ci): temporarily restrict to ubuntu-only until display workaround added

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,10 @@ jobs:
         node-version:
           - 20.x
         os:
+          # macOS and Windows temporarily disabled — VS Code extension tests
+          # require a display session; those runners hang and get cancelled.
+          # See https://github.com/accordproject/vscode-web-extension/issues/95
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
 
     runs-on: ${{ matrix.os }}
 
@@ -29,18 +30,11 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-    
+
       - run: npm ci
       - run: npm run package:vsix
       - run: npm install -g vsce
-    
+
       - name: Test
-        run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            xvfb-run -a npm test --silent
-          elif [ "$RUNNER_OS" == "Windows" ]; then
-            npm test
-          else
-            npm test --silent
-          fi
+        run: xvfb-run -a npm test --silent
         shell: bash


### PR DESCRIPTION
## Summary

- Removes macOS and Windows from the CI matrix temporarily
- VS Code extension tests require a display/GUI session; without one, those runners hang and are cancelled
- Ubuntu passes reliably using `xvfb-run`
- Also simplifies the `Test` step — the OS branching logic is no longer needed with a single platform

Closes #95 (temporarily) — the issue tracks adding a proper display workaround to restore macOS and Windows.

## Test plan
- [ ] CI passes on ubuntu-latest for open dependabot PRs