### PR TITLE
fix(ci): remove duplicate workflow runs by scoping push trigger to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary

- The `push` trigger in `build.yml` had no branch filter, causing every push to a PR branch to fire both the `push` and `pull_request` events — resulting in duplicate CI runs
- Scoped the `push` trigger to `main` only, matching the existing `pull_request` filter

## Test plan

- [ ] Verify CI runs once (not twice) on open dependabot PRs after this merges
- [ ] Verify CI still runs on direct pushes/merges to `main`